### PR TITLE
Support `additionalInformation` on clients

### DIFF
--- a/src/groovy/grails/plugin/springsecurity/oauthprovider/SpringSecurityOAuth2ProviderUtility.groovy
+++ b/src/groovy/grails/plugin/springsecurity/oauthprovider/SpringSecurityOAuth2ProviderUtility.groovy
@@ -37,6 +37,7 @@ class SpringSecurityOAuth2ProviderUtility {
 			client.authorities = clientConfig.authorities ?: defaultConfig.authorities
 			client.accessTokenValiditySeconds = clientConfig.accessTokenValiditySeconds ?: defaultConfig.accessTokenValiditySeconds
 			client.refreshTokenValiditySeconds = clientConfig.refreshTokenValiditySeconds ?: defaultConfig.refreshTokenValiditySeconds
+			client.additionalInformation = clientConfig.additionalInformation ?: defaultConfig.additionalInformation
 
 			// Add to client details service
 			log.debug("Adding client ${client.clientId} to client details service store")


### PR DESCRIPTION
The `additionalInformation` map from [BaseClientDetails](http://docs.spring.io/spring-security/oauth/apidocs/org/springframework/security/oauth2/provider/BaseClientDetails.html#getAdditionalInformation%28%29) can be used to add arbitrary data to a client object. This change supports reading `additionalInformation` blocks from clients defined in a config file.

In my project, we use `additionalInformation` to store a human-readable name and metadata on how the client should be handled.

I'm not aware of any problems from parsing `additionalInformation` in the config file, so I thought I'd submit this PR!
