### PR TITLE
Fix NPE when reading unknown access token

### DIFF
--- a/grails-app/services/grails/plugin/springsecurity/oauthprovider/GormTokenStoreService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauthprovider/GormTokenStoreService.groovy
@@ -76,6 +76,10 @@ class GormTokenStoreService implements TokenStore {
         def valuePropertyName = accessTokenLookup.valuePropertyName
         def gormAccessToken = GormAccessToken.findWhere((valuePropertyName): tokenValue)
 
+        if(!gormAccessToken) {
+            log.debug("Failed to find access token with value [$tokenValue]")
+            return null
+        }
         createOAuth2AccessToken(gormAccessToken)
     }
 

--- a/test/functional/test/oauth2/AbstractAccessControlFunctionalSpec.groovy
+++ b/test/functional/test/oauth2/AbstractAccessControlFunctionalSpec.groovy
@@ -56,6 +56,17 @@ abstract class AbstractAccessControlFunctionalSpec extends GebReportingSpec {
         }
     }
 
+    protected HttpResponseDecorator requestRawResponse(String relativeUrl, String token) {
+        try {
+            def requestUrl = browser.baseUrl + relativeUrl
+            def headers = [Authorization: "Bearer $token"]
+            restClient.get(uri: requestUrl, headers: headers) as HttpResponseDecorator
+        }
+        catch(HttpResponseException e) {
+            return e.response
+        }
+    }
+
     protected String getAccessToken(AccessTokenRequest request) {
 
         Map params = createParamsFromRequest(request)

--- a/test/functional/test/oauth2/SecuredControllerFunctionalSpec.groovy
+++ b/test/functional/test/oauth2/SecuredControllerFunctionalSpec.groovy
@@ -8,6 +8,15 @@ import spock.lang.Unroll
 
 class SecuredControllerFunctionalSpec extends AbstractAccessControlFunctionalSpec {
 
+    void "invalid bearer token in request"() {
+        when:
+        def response = requestRawResponse('secured/clientRole', 'invalid-bearer-token')
+
+        then:
+        response.status == 401
+        response.data.error == 'invalid_token'
+    }
+
     @Unroll
     void "client has role expression for grant type [#grantType]"() {
         given:

--- a/test/unit/grails/plugin/springsecurity/oauthprovider/GormTokenStoreServiceSpec.groovy
+++ b/test/unit/grails/plugin/springsecurity/oauthprovider/GormTokenStoreServiceSpec.groovy
@@ -217,6 +217,11 @@ class GormTokenStoreServiceSpec extends Specification {
         oAuthRefreshToken.value == refreshValue
     }
 
+    void "read access token returns null when token not found"() {
+        expect:
+        service.readAccessToken(tokenValue) == null
+    }
+
     void "return null if refresh token can't be read"() {
         expect:
         service.readRefreshToken(refreshValue) == null


### PR DESCRIPTION
This fixes a very minor bug in some of the GORM stuff that was merged in. To answer the question @bluesliverx raised in the other PR, I'm currently using this plugin for a project that is still in development and this has been the only issue I've run into so far.
