### PR TITLE
Avoid null pointer exception when access token does not exists

### DIFF
--- a/grails-app/services/grails/plugin/springsecurity/oauthprovider/GormTokenStoreService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauthprovider/GormTokenStoreService.groovy
@@ -167,7 +167,7 @@ class GormTokenStoreService implements TokenStore {
         def refreshTokenPropertyName = accessTokenLookup.refreshTokenPropertyName
         def gormAccessToken = GormAccessToken.findWhere((refreshTokenPropertyName): refreshToken.value)
 
-        gormAccessToken.delete()
+        gormAccessToken?.delete()
     }
 
     @Override


### PR DESCRIPTION
Sometimes the access token does not exist for some reason and a null pointer exception is thrown. Since it is going to be deleted anyway, the NPE can be ignored.
