### PR TITLE
Added null control in serializer

### DIFF
--- a/src/groovy/grails/plugin/springsecurity/oauthprovider/OAuth2AuthenticationSerializer.groovy
+++ b/src/groovy/grails/plugin/springsecurity/oauthprovider/OAuth2AuthenticationSerializer.groovy
@@ -10,6 +10,9 @@ class OAuth2AuthenticationSerializer {
     }
 
     OAuth2Authentication deserialize(byte[] authentication) {
+        if (authentication == null) {
+            return null
+        }
         new ByteArrayInputStream(authentication).withObjectInputStream(getClass().classLoader) { ois ->
             ois.readObject() as OAuth2Authentication
         }


### PR DESCRIPTION
Hello. Great work with the plugin :+1: 

I did have this problem when trying to retrieve a second token with a valid authorization code. As code has been deleted there is an uncotrolled error (null pointer exception)

When returning null the error is as expected "authorization code not valid"

Regards,
