### PR TITLE
Refactor OAuth2AuthenticationSerializer 

### DIFF
--- a/SpringSecurityOauth2ProviderGrailsPlugin.groovy
+++ b/SpringSecurityOauth2ProviderGrailsPlugin.groovy
@@ -14,7 +14,7 @@
  */
 
 import grails.plugin.springsecurity.SpringSecurityUtils
-import grails.plugin.springsecurity.oauthprovider.OAuth2AuthenticationSerializer
+import grails.plugin.springsecurity.oauthprovider.DefaultOAuth2AuthenticationSerializer
 import grails.plugin.springsecurity.oauthprovider.UserApprovalSupport
 import grails.plugin.springsecurity.oauthprovider.endpoint.RequiredRedirectResolver
 import grails.plugin.springsecurity.oauthprovider.endpoint.WrappedAuthorizationEndpoint
@@ -181,7 +181,7 @@ OAuth2 Provider support for the Spring Security plugin.
         springConfig.addAlias 'approvalStore', 'gormApprovalStoreService'
 
         /* Helper classes for Gorm support */
-        oauth2AuthenticationSerializer(OAuth2AuthenticationSerializer)
+        oauth2AuthenticationSerializer(DefaultOAuth2AuthenticationSerializer)
         authenticationKeyGenerator(DefaultAuthenticationKeyGenerator)
     }
 

--- a/src/groovy/grails/plugin/springsecurity/oauthprovider/DefaultOAuth2AuthenticationSerializer.groovy
+++ b/src/groovy/grails/plugin/springsecurity/oauthprovider/DefaultOAuth2AuthenticationSerializer.groovy
@@ -1,0 +1,20 @@
+package grails.plugin.springsecurity.oauthprovider
+
+import org.springframework.security.oauth2.provider.OAuth2Authentication
+import org.springframework.security.oauth2.common.util.SerializationUtils
+
+class DefaultOAuth2AuthenticationSerializer implements OAuth2AuthenticationSerializer {
+
+    Object serialize(OAuth2Authentication authentication) {
+        return SerializationUtils.serialize(authentication)
+    }
+
+    OAuth2Authentication deserialize(Object authentication) {
+        if (authentication == null) {
+            return null
+        }
+        new ByteArrayInputStream(authentication).withObjectInputStream(getClass().classLoader) { ois ->
+            return ois.readObject() as OAuth2Authentication
+        }
+    }
+}

--- a/src/groovy/grails/plugin/springsecurity/oauthprovider/OAuth2AuthenticationSerializer.groovy
+++ b/src/groovy/grails/plugin/springsecurity/oauthprovider/OAuth2AuthenticationSerializer.groovy
@@ -1,20 +1,12 @@
 package grails.plugin.springsecurity.oauthprovider
 
 import org.springframework.security.oauth2.provider.OAuth2Authentication
-import org.springframework.security.oauth2.common.util.SerializationUtils
 
-class OAuth2AuthenticationSerializer {
 
-    byte[] serialize(OAuth2Authentication authentication) {
-        SerializationUtils.serialize(authentication)
-    }
+interface OAuth2AuthenticationSerializer {
 
-    OAuth2Authentication deserialize(byte[] authentication) {
-        if (authentication == null) {
-            return null
-        }
-        new ByteArrayInputStream(authentication).withObjectInputStream(getClass().classLoader) { ois ->
-            ois.readObject() as OAuth2Authentication
-        }
-    }
+    Object serialize(OAuth2Authentication authentication)
+
+    OAuth2Authentication deserialize(Object authentication)
+
 }


### PR DESCRIPTION
This is to allow easier override, the major change is `byte[] serialize` changing to `Object serialize` I wanted to change my Gorm classes and use Strings instead with JSON. This should be transparent to most users only someone extending `OAuth2AuthenticationSerializer` should be effected.