### PR TITLE
I prepared a PR for issue #65

### DIFF
--- a/SpringSecurityOauth2ProviderGrailsPlugin.groovy
+++ b/SpringSecurityOauth2ProviderGrailsPlugin.groovy
@@ -33,6 +33,7 @@ import org.springframework.http.converter.FormHttpMessageConverter
 import org.springframework.http.converter.StringHttpMessageConverter
 import org.springframework.http.converter.json.MappingJacksonHttpMessageConverter
 import org.springframework.http.converter.xml.SourceHttpMessageConverter
+import org.springframework.security.authentication.ProviderManager
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider
 import org.springframework.security.oauth2.provider.CompositeTokenGranter
 import org.springframework.security.oauth2.provider.approval.ApprovalStoreUserApprovalHandler
@@ -55,6 +56,7 @@ import org.springframework.security.oauth2.provider.password.ResourceOwnerPasswo
 import org.springframework.security.oauth2.provider.refresh.RefreshTokenGranter
 import org.springframework.security.oauth2.provider.token.DefaultAuthenticationKeyGenerator
 import org.springframework.security.oauth2.provider.token.DefaultTokenServices
+import org.springframework.security.web.access.AccessDeniedHandlerImpl
 import org.springframework.security.web.access.ExceptionTranslationFilter
 import org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint
 import org.springframework.security.web.authentication.NullRememberMeServices
@@ -490,7 +492,13 @@ class SpringSecurityOauth2ProviderGrailsPlugin {
             // provides OAuth2 specific details
             oauth2AuthenticationDetailsSource(OAuth2AuthenticationDetailsSource)
 
-            basicAuthenticationFilter(BasicAuthenticationFilter, ref('authenticationManager'), ref('oauth2AuthenticationEntryPoint')) {
+            basicClientAuthenticationManager(ProviderManager) {
+                providers = [ ref('clientCredentialsAuthenticationProvider') ]
+                authenticationEventPublisher = ref('authenticationEventPublisher')
+                eraseCredentialsAfterAuthentication = conf.providerManager.eraseCredentialsAfterAuthentication // true
+            }
+
+            basicAuthenticationFilter(BasicAuthenticationFilter, ref('basicClientAuthenticationManager'), ref('oauth2AuthenticationEntryPoint')) {
                 authenticationDetailsSource = ref('oauth2AuthenticationDetailsSource')
                 rememberMeServices = ref('statelessRememberMeServices')
                 credentialsCharset = conf.basic.credentialsCharset

--- a/SpringSecurityOauth2ProviderGrailsPlugin.groovy
+++ b/SpringSecurityOauth2ProviderGrailsPlugin.groovy
@@ -482,7 +482,7 @@ class SpringSecurityOauth2ProviderGrailsPlugin {
         if(registerBasicAuthFilter) {
             // This defines the bean using the alternative constructor that sets ignoreFailure to true,
             // as an alternative to the filter offered by the Spring Security Core plugin:
-            basicAuthenticationFilter(BasicAuthenticationFilter, ref('authenticationManager')) {
+            basicAuthenticationFilter(BasicAuthenticationFilter, ref('authenticationManager', ref('oauth2AuthenticationEntryPoint'))) {
                 authenticationDetailsSource = ref('authenticationDetailsSource')
                 rememberMeServices = ref('rememberMeServices')
                 credentialsCharset = conf.basic.credentialsCharset

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -1,7 +1,9 @@
 
 log4j = {
-    debug  'grails.plugin.springsecurity.oauthprovider',
-            'test.oauth2'
+    debug   'grails.plugin.springsecurity.oauthprovider',
+            'test.oauth2',
+            'org.springframework.security.oauth2.provider.authentication',
+            'org.springframework.security.authentication'
 
 	warn	'grails.plugin.springsecurity',
 			'org.springframework.security'
@@ -36,7 +38,7 @@ grails.plugin.springsecurity.controllerAnnotations.staticRules = [
 ]
 
 grails.plugin.springsecurity.providerNames = [
-        'clientCredentialsAuthenticationProvider',
+//        'clientCredentialsAuthenticationProvider',
         'daoAuthenticationProvider',
         'anonymousAuthenticationProvider',
         'rememberMeAuthenticationProvider'

--- a/grails-app/conf/DefaultOAuth2ProviderSecurityConfig.groovy
+++ b/grails-app/conf/DefaultOAuth2ProviderSecurityConfig.groovy
@@ -29,6 +29,9 @@ security {
         statelessFilterStartPosition = SecurityFilterPosition.SECURITY_CONTEXT_FILTER.order
         registerStatelessFilter = true
 
+        basicAuthFilterStartPosition = SecurityFilterPosition.BASIC_AUTH_FILTER.order
+        registerBasicAuthFilter = true
+
         realmName = 'Grails OAuth2 Realm'
 
         tokenServices {

--- a/test/functional/helper/AccessTokenRequester.groovy
+++ b/test/functional/helper/AccessTokenRequester.groovy
@@ -16,6 +16,7 @@ class AccessTokenRequester {
     }
 
     static String getAccessToken(Map params) {
+        params = params.clone() // Don't mess with the original Map
         String clientId = params.remove('client_id')
         String clientSecret = params.remove('client_secret') ?: ''
 

--- a/test/functional/helper/AccessTokenRequester.groovy
+++ b/test/functional/helper/AccessTokenRequester.groovy
@@ -16,7 +16,13 @@ class AccessTokenRequester {
     }
 
     static String getAccessToken(Map params) {
-        def response = requestAccessToken(params)
+        String clientId = params.remove('client_id')
+        String clientSecret = params.remove('client_secret') ?: ''
+
+        def response = clientId != null ?
+                requestAccessTokenWithBasicAuth(params, clientId, clientSecret) :
+                requestAccessToken(params)
+
         return response.data.access_token
     }
 

--- a/test/functional/helper/AccessTokenRequester.groovy
+++ b/test/functional/helper/AccessTokenRequester.groovy
@@ -7,16 +7,21 @@ import groovyx.net.http.RESTClient
 class AccessTokenRequester {
 
     private static RESTClient restClient = new RESTClient()
+    private static final boolean USE_HTTP_BASIC = true
 
     private static final BASE_URL = System.getProperty(BuildSettings.FUNCTIONAL_BASE_URL_PROPERTY)
     static final TOKEN_ENDPOINT_URL = BASE_URL + 'oauth/token'
 
     static HttpResponseDecorator requestAccessToken(Map requestParams) {
-        Map params = requestParams.clone() // Don't mess with the original Map
-        String clientId = params.remove('client_id')
-        String clientSecret = params.remove('client_secret') ?: ''
+        if (USE_HTTP_BASIC) {
+            Map params = requestParams.clone() // Don't mess with the original Map
+            String clientId = params.remove('client_id')
+            String clientSecret = params.remove('client_secret') ?: ''
 
-        requestAccessTokenWithBasicAuth(params, clientId, clientSecret)
+            requestAccessTokenWithBasicAuth(params, clientId, clientSecret)
+        } else {
+            restClient.post(uri: TOKEN_ENDPOINT_URL, query: requestParams)
+        }
     }
 
     static String getAccessToken(Map params) {

--- a/test/functional/helper/AccessTokenRequester.groovy
+++ b/test/functional/helper/AccessTokenRequester.groovy
@@ -11,19 +11,16 @@ class AccessTokenRequester {
     private static final BASE_URL = System.getProperty(BuildSettings.FUNCTIONAL_BASE_URL_PROPERTY)
     static final TOKEN_ENDPOINT_URL = BASE_URL + 'oauth/token'
 
-    static HttpResponseDecorator requestAccessToken(Map params) {
-        restClient.post(uri: TOKEN_ENDPOINT_URL, query: params)
-    }
-
-    static String getAccessToken(Map params) {
-        params = params.clone() // Don't mess with the original Map
+    static HttpResponseDecorator requestAccessToken(Map requestParams) {
+        Map params = requestParams.clone() // Don't mess with the original Map
         String clientId = params.remove('client_id')
         String clientSecret = params.remove('client_secret') ?: ''
 
-        def response = clientId != null ?
-                requestAccessTokenWithBasicAuth(params, clientId, clientSecret) :
-                requestAccessToken(params)
+        requestAccessTokenWithBasicAuth(params, clientId, clientSecret)
+    }
 
+    static String getAccessToken(Map params) {
+        def response = requestAccessToken(params)
         return response.data.access_token
     }
 
@@ -34,7 +31,7 @@ class AccessTokenRequester {
 
     static HttpResponseDecorator requestAccessTokenWithBasicAuth(Map params, String clientId, String clientSecret) {
         def basicAuth = "$clientId:$clientSecret".bytes.encodeBase64()
-        def headers = [Authorization: "Basic $basicAuth"]
+        def headers = clientId ? [Authorization: "Basic $basicAuth"] : [:]
         restClient.post(uri: TOKEN_ENDPOINT_URL, query: params, headers: headers)
     }
 }

--- a/test/functional/helper/ErrorDescriptions.groovy
+++ b/test/functional/helper/ErrorDescriptions.groovy
@@ -25,4 +25,9 @@ class ErrorDescriptions {
     static String unableToNarrowScope(String scope) {
         return "Unable to narrow the scope of the client authentication to [$scope]."
     }
+
+    static String noClientWithRequestedId(String clientId) {
+        return "No client with requested id: $clientId"
+    }
+
 }

--- a/test/functional/test/oauth2/AuthorizationCodeFunctionalSpec.groovy
+++ b/test/functional/test/oauth2/AuthorizationCodeFunctionalSpec.groovy
@@ -214,7 +214,8 @@ class AuthorizationCodeFunctionalSpec extends AbstractAuthorizationEndpointFunct
 
         then:
         def tokenEndpointParams = createTokenEndpointParams('confidential-client')
-        assertAccessTokenErrorRequest(tokenEndpointParams, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        // assertAccessTokenErrorRequest(tokenEndpointParams, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        assertAccessTokenErrorRequest(tokenEndpointParams, 401, 'unauthorized', BAD_CREDENTIALS)
     }
 
     @Unroll

--- a/test/functional/test/oauth2/ClientCredentialsFunctionalSpec.groovy
+++ b/test/functional/test/oauth2/ClientCredentialsFunctionalSpec.groovy
@@ -33,7 +33,8 @@ class ClientCredentialsFunctionalSpec extends AbstractTokenEndpointFunctionalSpe
         params << [client_id: 'confidential-client']
 
         expect:
-        assertAccessTokenErrorRequest(params, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        //assertAccessTokenErrorRequest(params, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        assertAccessTokenErrorRequest(params, 401, 'unauthorized', BAD_CREDENTIALS)
     }
 
     void "client credentials with confidential client and incorrect client secret"() {
@@ -41,7 +42,8 @@ class ClientCredentialsFunctionalSpec extends AbstractTokenEndpointFunctionalSpe
         params << [client_id: 'confidential-client', client_secret: 'incorrect']
 
         expect:
-        assertAccessTokenErrorRequest(params, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        //assertAccessTokenErrorRequest(params, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        assertAccessTokenErrorRequest(params, 401, 'unauthorized', BAD_CREDENTIALS)
     }
 
     void "client credentials with confidential client"() {

--- a/test/functional/test/oauth2/ResourceOwnerCredentialsFunctionalSpec.groovy
+++ b/test/functional/test/oauth2/ResourceOwnerCredentialsFunctionalSpec.groovy
@@ -25,7 +25,8 @@ class ResourceOwnerCredentialsFunctionalSpec extends AbstractTokenEndpointFuncti
         params << [client_id: 'confidential-client']
 
         expect:
-        assertAccessTokenErrorRequest(params, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        //assertAccessTokenErrorRequest(params, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        assertAccessTokenErrorRequest(params, 401, 'unauthorized', BAD_CREDENTIALS)
     }
 
     void "resource owner credentials with confidential client and incorrect client secret"() {
@@ -33,7 +34,8 @@ class ResourceOwnerCredentialsFunctionalSpec extends AbstractTokenEndpointFuncti
         params << [client_id: 'confidential-client', client_secret: 'incorrect']
 
         expect:
-        assertAccessTokenErrorRequest(params, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        //assertAccessTokenErrorRequest(params, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS)
+        assertAccessTokenErrorRequest(params, 401, 'unauthorized', BAD_CREDENTIALS)
     }
 
     void "resource owner credentials unknown user"() {

--- a/test/functional/test/oauth2/TokenEndpointFunctionalSpec.groovy
+++ b/test/functional/test/oauth2/TokenEndpointFunctionalSpec.groovy
@@ -30,10 +30,12 @@ class TokenEndpointFunctionalSpec extends AbstractTokenEndpointFunctionalSpec {
     @Unroll
     void "invalid client requested for grant_type [#grantType]"() {
         given:
-        def params = [grant_type: grantType, client_id: 'invalid-client']
+        def clientId = 'invalid-client'
+        def params = [grant_type: grantType, client_id: clientId]
 
         expect:
-        assertAccessTokenErrorRequest(params, 401, 'invalid_client', BAD_CLIENT_CREDENTIALS, true)
+        //assertAccessTokenErrorRequest(params, 401, 'invalid_client', noClientWithRequestedId('invalid-client'), true)
+        assertAccessTokenErrorRequest(params, 401, 'unauthorized', noClientWithRequestedId('invalid-client'))
 
         where:
         _   |   grantType

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -15,25 +15,27 @@ plugin=${plugin/-SNAPSHOT/}
 version="${plugin#*-}";
 plugin=${plugin/"-$version"/}
 
-echo "Publishing plugin grails-spring-security-core with version $version"
+if [ $TRAVIS_PULL_REQUEST == 'false' ]; then
+  echo "Publishing plugin grails-spring-security-core with version $version"
 
-if [[ $filename != *-SNAPSHOT* && $TRAVIS_REPO_SLUG == 'bluesliverx/grails-spring-security-oauth2-provider' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
-  git config --global user.name "$GIT_NAME"
-  git config --global user.email "$GIT_EMAIL"
-  git config --global credential.helper "store --file=~/.git-credentials"
-  echo "https://$GITHUB_TOKEN:@github.com" > ~/.git-credentials
-  git clone https://${GITHUB_TOKEN}@github.com/$TRAVIS_REPO_SLUG.git -b gh-pages gh-pages --single-branch > /dev/null
-  cd gh-pages
-  git rm -rf .
-  cp -r ../docs/. ./
-  git add *
-  git commit -a -m "Updating docs for Travis build: https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID"
-  git push origin HEAD
-  cd ..
-  rm -rf gh-pages
-else
-  echo "Not doing a release, so not publishing docs"
+  if [[ $filename != *-SNAPSHOT* && $TRAVIS_REPO_SLUG == 'bluesliverx/grails-spring-security-oauth2-provider' ]]; then
+    git config --global user.name "$GIT_NAME"
+    git config --global user.email "$GIT_EMAIL"
+    git config --global credential.helper "store --file=~/.git-credentials"
+    echo "https://$GITHUB_TOKEN:@github.com" > ~/.git-credentials
+    git clone https://${GITHUB_TOKEN}@github.com/$TRAVIS_REPO_SLUG.git -b gh-pages gh-pages --single-branch > /dev/null
+    cd gh-pages
+    git rm -rf .
+    cp -r ../docs/. ./
+    git add *
+    git commit -a -m "Updating docs for Travis build: https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID"
+    git push origin HEAD
+    cd ..
+    rm -rf gh-pages
+  else
+    echo "Not doing a release, so not publishing docs"
+  fi
+
+  # Publish plugin
+  ./grailsw publish-plugin --allow-overwrite --non-interactive --stacktrace
 fi
-
-# Publish plugin
-./grailsw publish-plugin --allow-overwrite --non-interactive --stacktrace


### PR DESCRIPTION
This adds support for accepting client credentials via the HTTP Basic authentication scheme.

The `DefaultOAuth2ProviderSecurityConfig` contains a new parameter called `registerBasicAuthFilter` to enable/disable the registration of the `BasicAuthenticationFilter`.

Since the HTTP Basic authentication scheme is recommended by the RFC, with parameters in the request-body as a fallback for clients unable to use this method, I suggest enabling the `BasicAuthenticationFilter` by default. 

This is *not compatible* with the `BasicAuthenticationFilter` defined by the Spring Security Core plugin when setting `grails.plugin.springsecurity.useBasicAuth` to `true`. This at least should be clear in the documentation; perhaps we should even test for it and generate a warning.

The relevant part in the OAuth2 spec is this:

    Including the client credentials in the request-body using the two
    parameters is NOT RECOMMENDED and SHOULD be limited to clients unable
    to directly utilize the HTTP Basic authentication scheme (or other
    password-based HTTP authentication schemes).  The parameters can only
    be transmitted in the request-body and MUST NOT be included in the
    request URI.