### PR TITLE
Make readAuthentication null safe.

### DIFF
--- a/grails-app/services/grails/plugin/springsecurity/oauthprovider/GormTokenStoreService.groovy
+++ b/grails-app/services/grails/plugin/springsecurity/oauthprovider/GormTokenStoreService.groovy
@@ -43,9 +43,11 @@ class GormTokenStoreService implements TokenStore {
             def authenticationPropertyName = accessTokenLookup.authenticationPropertyName
 
             def gormAccessToken = GormAccessToken.findWhere((valuePropertyName): token)
-            def serializedAuthentication = gormAccessToken."$authenticationPropertyName"
+            if(gormAccessToken) {
+                def serializedAuthentication = gormAccessToken."$authenticationPropertyName"
 
-            authentication = oauth2AuthenticationSerializer.deserialize(serializedAuthentication)
+                authentication = oauth2AuthenticationSerializer.deserialize(serializedAuthentication)
+            }
         }
         catch (IllegalArgumentException e) {
             checkForDomainConfigurationRelatedException(e, 'access', accessTokenLookup.className)


### PR DESCRIPTION
Matching the behavior of JdbcTokenStore which will return a null authentication if there is no resource found for a given access token string.

This comes up when using the token store directly.