### PR TITLE
Adding explicit transactional support to address issue #114

### DIFF
--- a/spring-security-oauth2-provider/grails-app/services/grails/plugin/springsecurity/oauthprovider/GormClientDetailsService.groovy
+++ b/spring-security-oauth2-provider/grails-app/services/grails/plugin/springsecurity/oauthprovider/GormClientDetailsService.groovy
@@ -3,12 +3,14 @@ package grails.plugin.springsecurity.oauthprovider
 import grails.plugin.springsecurity.SpringSecurityUtils
 import grails.plugin.springsecurity.oauthprovider.serialization.OAuth2AdditionalInformationSerializer
 import grails.core.GrailsApplication
+import grails.transaction.Transactional
 import org.springframework.security.oauth2.provider.client.BaseClientDetails
 import org.springframework.security.oauth2.provider.ClientDetails
 import org.springframework.security.oauth2.provider.ClientDetailsService
 import org.springframework.security.oauth2.provider.ClientRegistrationException
 import org.springframework.security.oauth2.provider.NoSuchClientException
 
+@Transactional(readOnly = true)
 class GormClientDetailsService implements ClientDetailsService {
 
     GrailsApplication grailsApplication


### PR DESCRIPTION
It looks like grails 3.1.x dropped the default transactional support for services.

> In addition, prior to Grails 3.1 services were transactional by default, as of Grails 3.1 they are only transactional if the @Transactional transformation is applied.
