### PR TITLE
Fix link for Grails Plugin Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Grails Spring Security OAuth2 Provider Plugin
 [![Build Status](https://travis-ci.org/bluesliverx/grails-spring-security-oauth2-provider.svg?branch=master)](https://travis-ci.org/bluesliverx/grails-spring-security-oauth2-provider)
 
 See [documentation](http://bluesliverx.github.io/grails-spring-security-oauth2-provider/) and the
-[Grails plugin page](http://grails.org/plugin/spring-security-oauth2-provider) for further information.
+[Grails plugin page](https://grails.org/plugins.html#plugin/spring-security-oauth2-provider) for further information.


### PR DESCRIPTION
Point to the updated grails plugin page URL.

Current link is a 404.