### PR TITLE
Avoid loading secondary config inside applicationContext

### DIFF
--- a/spring-security-oauth2-provider/src/main/groovy/grails/plugin/springsecurity/oauthprovider/SpringSecurityOauth2ProviderGrailsPlugin.groovy
+++ b/spring-security-oauth2-provider/src/main/groovy/grails/plugin/springsecurity/oauthprovider/SpringSecurityOauth2ProviderGrailsPlugin.groovy
@@ -568,8 +568,8 @@ class SpringSecurityOauth2ProviderGrailsPlugin extends Plugin {
 
     @Override
     void doWithApplicationContext() {
-        def conf = loadSecurityConfig()
-        if(!conf) {
+        def conf = SpringSecurityUtils.securityConfig
+        if(!conf || !conf.active || !conf.oauthProvider.active) {
             return
         }
 


### PR DESCRIPTION
Fixes https://github.com/bluesliverx/grails-spring-security-oauth2-provider/issues/138

Calling loadSecondaryConfig after the application has been initialized seems to break spring boot property resolution. Simply chceking the configuration values at runtime suffices because they were loaded inside doWithSpring.

Please let me know if I've missed anything.