### PR TITLE
Fix plugin portal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Grails Spring Security OAuth2 Provider Plugin
 [![Build Status](https://travis-ci.org/bluesliverx/grails-spring-security-oauth2-provider.svg?branch=master)](https://travis-ci.org/bluesliverx/grails-spring-security-oauth2-provider)
 
 See [documentation](http://bluesliverx.github.io/grails-spring-security-oauth2-provider/) and the
-[Grails plugin page](https://grails.org/plugins.html#plugin/spring-security-oauth2-provider) for further information.
+[Grails plugin page](http://plugins.grails.org/plugin/bluesliverx/spring-security-oauth2-provider) for further information.


### PR DESCRIPTION
Fix the plugin portal link (again).

The current link is 404 again. I searched for this plugin from the plugin portal and copied the URL and pasted it as the new link target.